### PR TITLE
3 automatizar cierre de read datajson tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # django-datajsonar
+
+## Configuración
+
+### Scheduling de trabajos
+
+Los comandos `schedule_indexation` y `schedule_task_finisher` permiten planificar trabajos que se ejecutarán de manera
+periódica. Es posible definir un horario de inicio, un intervalo de tiempo entre corridas y la función a ejecutar. Los
+parámetros son idénticos para los dos comandos.
+
+`$[schedule_indexation|schedule_task_finisher] NAME -t HOUR MINUTE -i UNIT [weeks|days|hours|minutes] -c CALLABLE`
+
+Los comandos toman los siguientes parámetros:
+  - **Name**: Es el nombre con que queda registrado el trabajo. Si el nombre pertenece a un trabajo ya registrado, se
+  procederá a actualizarlo con los valores pasados.
+  - **Time**: La hora de inicio del trabajo, efectivo al día siguiente. Por default en `schedule_indexation` son las 6
+  de la mañana (hora UTC); para `schedule_task_finisher` es la medianoche (UTC).
+  - **Interval**: El intervalo de tiempo que se deja entre corrida y corrida. Por default en `schedule_indexation` es
+  24 horas; para `schedule_task_finisher` son 5 minutos.
+  - **Callable**: La función que se ejecutará en los horarios e intervalos definidos. Por default en
+  `schedule_indexation` es `django_datajsonar.libs.indexing.tasks.schedule_new_read_datajson_task`; para
+  `schedule_task_finisher` es `django_datajsonar.libs.indexing.tasks.close_read_datajson_task`.
+
+En caso de querer registrar un trabajo con callable e intervalo iguales a un trabajo ya registrado, se notificará la
+situación y se preservará el trabajo original sin guardar el nuevo.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ Los comandos `schedule_indexation` y `schedule_task_finisher` permiten planifica
 periódica. Es posible definir un horario de inicio, un intervalo de tiempo entre corridas y la función a ejecutar. Los
 parámetros son idénticos para los dos comandos.
 
-`$[schedule_indexation|schedule_task_finisher] NAME -t HOUR MINUTE -i UNIT [weeks|days|hours|minutes] -c CALLABLE`
+Por default, `schedule_indexation` ejecuta periódicamente `schedule_new_read_datajson_task`. Esta función crea nuevas
+tareas que iteran sobre los nodos indexables de la red de catálogos y sobre sus datasets creando o actualizando su
+metadata en los modelos dependiendo del caso que corresponda. En el caso de `schedule_task_finisher`, por default corre
+`close_read_datajson_task`. Esta función marca como finalizadas los `ReadDataJsonTask` una vez que terminan para poder
+crear nuevas tareas. En conjunto, estos trabajos permiten crear, poblar y actualizar los modelos indexables de manera
+periódica y automática. 
+
+Para ejecutar el comando hay que llamar: 
+
+`$ python manage.py [schedule_indexation|schedule_task_finisher] NAME -t HOUR MINUTE -i UNIT [weeks|days|hours|minutes] -c CALLABLE`
 
 Los comandos toman los siguientes parámetros:
   - **Name**: Es el nombre con que queda registrado el trabajo. Si el nombre pertenece a un trabajo ya registrado, se

--- a/django_datajsonar/apps/management/management/commands/schedule_indexation.py
+++ b/django_datajsonar/apps/management/management/commands/schedule_indexation.py
@@ -8,10 +8,6 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    """Comando para ejecutar la indexación manualmente de manera sincrónica,
-    útil para debugging. No correr junto con el rqscheduler para asegurar
-    la generación de reportes correcta."""
-
     def add_arguments(self, parser):
         add_common_arguments(parser)
         parser.set_defaults(callable='django_datajsonar.libs.indexing.tasks.schedule_new_read_datajson_task',

--- a/django_datajsonar/apps/management/management/commands/schedule_task_finisher.py
+++ b/django_datajsonar/apps/management/management/commands/schedule_task_finisher.py
@@ -1,6 +1,8 @@
 #! coding: utf-8
 import logging
+import datetime
 
+from django.utils.timezone import now
 from django.core.management import BaseCommand
 from ._utils import add_common_arguments, handle_command
 
@@ -14,9 +16,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         add_common_arguments(parser)
-        parser.set_defaults(callable='django_datajsonar.libs.indexing.tasks.schedule_new_read_datajson_task',
-                            time=[6, 0],
-                            interval=[24, 'hours'])
+        parser.set_defaults(callable='django_datajsonar.libs.indexing.tasks.close_read_datajson_task',
+                            time=[0, 0],
+                            interval=[5, 'minutes'])
 
     def handle(self, *args, **options):
         handle_command(options, logger)

--- a/django_datajsonar/apps/management/management/commands/schedule_task_finisher.py
+++ b/django_datajsonar/apps/management/management/commands/schedule_task_finisher.py
@@ -10,10 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    """Comando para ejecutar la indexación manualmente de manera sincrónica,
-    útil para debugging. No correr junto con el rqscheduler para asegurar
-    la generación de reportes correcta."""
-
     def add_arguments(self, parser):
         add_common_arguments(parser)
         parser.set_defaults(callable='django_datajsonar.libs.indexing.tasks.close_read_datajson_task',

--- a/django_datajsonar/apps/management/tests/scheduler_tests.py
+++ b/django_datajsonar/apps/management/tests/scheduler_tests.py
@@ -59,7 +59,6 @@ class ReadDataJsonTest(TestCase):
                                                          interval=300,
                                                          interval_unit='minutes'))
 
-
     def test_pass_callable_argument(self):
         for profile in self.profiles:
             args = [profile['command']+'_name']

--- a/django_datajsonar/libs/indexing/tasks.py
+++ b/django_datajsonar/libs/indexing/tasks.py
@@ -55,7 +55,7 @@ def get_dataset(catalog, catalog_id, dataset_id, whitelist):
 
 
 # Para correr con el scheduler
-def scheduler():
+def close_read_datajson_task():
     task = ReadDataJsonTask.objects.last()
     if task.status == task.FINISHED:
         return


### PR DESCRIPTION
Closes #3 

Agrega el comando `schedule_task_finisher`, en esencia es igual al `schedule_indexation` con la diferencia en nombre y que define otros valores de default.