### PR TITLE
Robustecer el manejo de tareas de management

### DIFF
--- a/django_datajsonar/apps/management/actions.py
+++ b/django_datajsonar/apps/management/actions.py
@@ -61,7 +61,8 @@ def process_node_register_file(register_file):
     yml = indexing_file.read()
     nodes = yaml.load(yml)
     for node, values in nodes.items():
-        if bool(values['federado']) is True:  # evitar entrar al branch con un valor truthy
+        # evitar entrar al branch con un valor truthy
+        if bool(values['federado']) is True and values['formato'] == 'json':
             Node.objects.get_or_create(catalog_id=node,
                                        catalog_url=values['url'],
                                        indexable=True)

--- a/django_datajsonar/apps/management/tasks.py
+++ b/django_datajsonar/apps/management/tasks.py
@@ -1,5 +1,7 @@
 #! coding: utf-8
 
+import logging
+
 from django.utils import timezone
 from django_rq import job
 
@@ -8,6 +10,7 @@ from django_datajsonar.apps.management.models import Node, DatasetIndexingFile
 from django_datajsonar.apps.management.strings import FILE_READ_ERROR
 from django_datajsonar.libs.indexing.catalog_reader import index_catalog
 
+logger = logging.getLogger(__name__)
 
 @job('indexing')
 def read_datajson(task, whitelist=False, read_local=False):
@@ -16,7 +19,10 @@ def read_datajson(task, whitelist=False, read_local=False):
     """
     nodes = Node.objects.filter(indexable=True)
     for node in nodes:
-        index_catalog(node, task, read_local, whitelist)
+        try:
+            index_catalog(node, task, read_local, whitelist)
+        except Exception as e:
+            logger.error(u"Excepción en leyendo nodo {}: {}".format(node.id, e.message))
 
 
 @job('indexing')

--- a/django_datajsonar/libs/indexing/catalog_reader.py
+++ b/django_datajsonar/libs/indexing/catalog_reader.py
@@ -26,6 +26,7 @@ def index_catalog(node, task, read_local=False, whitelist=False):
 
     try:
         catalog = DataJson(node.catalog_url)
+        catalog.generate_distribution_ids()
         node.catalog = json.dumps(catalog)
         node.save()
     except Exception as e:


### PR DESCRIPTION
Por el momento, solo leer los catálogos con formato json. Atrapar excepción en `index_catalog()` y seguir con la indexacion de los nodos y generar los ids de distribuciones en caso de que no esten presentes.