### PR TITLE
Procesar asincronicamente los nodos

### DIFF
--- a/django_datajsonar/apps/management/actions.py
+++ b/django_datajsonar/apps/management/actions.py
@@ -1,6 +1,7 @@
 #! coding: utf-8
 import unicodecsv
 import yaml
+from django_rq import job
 
 from django_datajsonar.apps.api.models import Catalog, Dataset
 from .models import Node, NodeRegisterFile
@@ -55,6 +56,7 @@ class DatasetIndexableToggler(object):
                 self.logs.append(DATASET_STATUS.format(catalog, dataset, status))
 
 
+@job('indexing')
 def process_node_register_file(register_file):
     """Registra (crea objetos Node) los nodos marcados como federado en el registro"""
     indexing_file = register_file.indexing_file

--- a/django_datajsonar/apps/management/actions.py
+++ b/django_datajsonar/apps/management/actions.py
@@ -6,7 +6,6 @@ from django_rq import job
 from django_datajsonar.apps.api.models import Catalog, Dataset
 from .models import Node, NodeRegisterFile
 from .strings import DATASET_STATUS
-from .tasks import process_node_register_file
 
 CATALOG_HEADER = u'catalog_id'
 DATASET_ID_HEADER = u'dataset_identifier'
@@ -57,9 +56,9 @@ class DatasetIndexableToggler(object):
                 self.logs.append(DATASET_STATUS.format(catalog, dataset, status))
 
 
-
 def process_node_register_file_action(register_file):
     """Registra (crea objetos Node) los nodos marcados como federado en el registro"""
+    from .tasks import process_node_register_file
     process_node_register_file.delay(register_file.id)
 
 

--- a/django_datajsonar/apps/management/admin.py
+++ b/django_datajsonar/apps/management/admin.py
@@ -32,7 +32,7 @@ class NodeRegisterFileAdmin(BaseRegisterFileAdmin):
             model.state = NodeRegisterFile.state = NodeRegisterFile.PROCESSING
             model.logs = u'-'
             model.save()
-            process_node_register_file(model)
+            process_node_register_file.delay(model)
 
 
 class NodeAdmin(admin.ModelAdmin):

--- a/django_datajsonar/apps/management/tasks.py
+++ b/django_datajsonar/apps/management/tasks.py
@@ -1,12 +1,13 @@
 #! coding: utf-8
 
 import logging
+import yaml
 
 from django.utils import timezone
 from django_rq import job
 
 from django_datajsonar.apps.management.actions import DatasetIndexableToggler
-from django_datajsonar.apps.management.models import Node, DatasetIndexingFile
+from django_datajsonar.apps.management.models import Node, DatasetIndexingFile, NodeRegisterFile
 from django_datajsonar.apps.management.strings import FILE_READ_ERROR
 from django_datajsonar.libs.indexing.catalog_reader import index_catalog
 


### PR DESCRIPTION
La acción de procesar un nodo se hace asincronicamente al llamar a `process_node_register_file_action()`. Además saca la dependencia de un campo `dataset_identifier` en las distribuciones.