### PR TITLE
35 robustecer bulk whitelist

### DIFF
--- a/django_datajsonar/actions.py
+++ b/django_datajsonar/actions.py
@@ -4,7 +4,7 @@ import unicodecsv
 import yaml
 
 from django_datajsonar.models import Catalog, Dataset
-from .strings import DATASET_STATUS
+from .strings import DATASET_STATUS, CATALOG_STATUS
 
 CATALOG_HEADER = u'catalog_id'
 DATASET_ID_HEADER = u'dataset_identifier'
@@ -42,9 +42,15 @@ class DatasetIndexableToggler(object):
 
     def update_database(self):
         for catalog, datasets in self.catalogs.items():
-            dataset_models = Catalog.objects.get(identifier=catalog).dataset_set
+            status = 'OK'
+            try:
+                dataset_models = Catalog.objects.get(identifier=catalog).dataset_set
+            except Catalog.DoesNotExist:
+                status = 'ERROR'
+                self.logs.append(CATALOG_STATUS.format(catalog, status))
+                return
+
             for dataset in datasets:
-                status = 'OK'
                 try:
                     dataset_model = dataset_models.get(identifier=dataset)
                     dataset_model.indexable = True

--- a/django_datajsonar/actions.py
+++ b/django_datajsonar/actions.py
@@ -48,7 +48,7 @@ class DatasetIndexableToggler(object):
             except Catalog.DoesNotExist:
                 status = 'ERROR'
                 self.logs.append(CATALOG_STATUS.format(catalog, status))
-                return
+                continue
 
             for dataset in datasets:
                 try:

--- a/django_datajsonar/strings.py
+++ b/django_datajsonar/strings.py
@@ -1,4 +1,4 @@
 #! coding: utf-8
-
+CATALOG_STATUS = u"Catalogo {}, status: {}"
 DATASET_STATUS = u"Dataset ({}, {}) status: {}"
 FILE_READ_ERROR = u"Error en la lectura del archivo de entrada"

--- a/django_datajsonar/tests/samples/test_missing_catalog.csv
+++ b/django_datajsonar/tests/samples/test_missing_catalog.csv
@@ -1,0 +1,4 @@
+catalog_id,dataset_identifier
+nonexistant,1
+test,1
+nonexistant,2


### PR DESCRIPTION
Durante el `bulk_whitelist()`, en caso de no encontrarse el catalogo indicado por id, marca el error en los logs del DatasetIndexingFile y continua con la ejecución.