### PR TITLE
Fix time series only

### DIFF
--- a/django_datajsonar/indexing/database_loader.py
+++ b/django_datajsonar/indexing/database_loader.py
@@ -90,7 +90,7 @@ class DatabaseLoader(object):
         updated_distributions = False
         distributions = dataset.get('distribution', [])
         if getattr(settings, 'DATAJSON_AR_TIME_SERIES_ONLY', False):
-            distributions = [dist for dist in distributions if distribution_has_time_index(dist)]
+            distributions = filter(distribution_has_time_index, distributions)
         for distribution in distributions:
             try:
                 distribution_model = self._distribution_model(distribution, dataset_model)

--- a/django_datajsonar/indexing/database_loader.py
+++ b/django_datajsonar/indexing/database_loader.py
@@ -88,7 +88,7 @@ class DatabaseLoader(object):
             defaults={'title': trimmed_dataset.get('title', 'No Title')}
         )
         updated_distributions = False
-        distributions = set(dataset.get('distribution', []))
+        distributions = dataset.get('distribution', [])
         if getattr(settings, 'DATAJSON_AR_TIME_SERIES_ONLY', False):
             distributions = [dist for dist in distributions if distribution_has_time_index(dist)]
         for distribution in distributions:

--- a/django_datajsonar/indexing/database_loader.py
+++ b/django_datajsonar/indexing/database_loader.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.files import File
 from django.utils import timezone
 from pydatajson import DataJson
+from pydatajson.time_series import distribution_has_time_index
 
 from django_datajsonar.models import ReadDataJsonTask
 from django_datajsonar.models import Dataset, Catalog, Distribution, Field
@@ -87,7 +88,10 @@ class DatabaseLoader(object):
             defaults={'title': trimmed_dataset.get('title', 'No Title')}
         )
         updated_distributions = False
-        for distribution in dataset.get('distribution', []):
+        distributions = set(dataset.get('distribution', []))
+        if getattr(settings, 'DATAJSON_AR_TIME_SERIES_ONLY', False):
+            distributions = [dist for dist in distributions if distribution_has_time_index(dist)]
+        for distribution in distributions:
             try:
                 distribution_model = self._distribution_model(distribution, dataset_model)
                 updated_distributions = updated_distributions or distribution_model.updated

--- a/django_datajsonar/indexing/tests/loader_tests.py
+++ b/django_datajsonar/indexing/tests/loader_tests.py
@@ -115,8 +115,8 @@ class DatabaseLoaderTests(TestCase):
 
         # Al cambiar identificadores, se duplican los modelos, pero solo uno queda presente
         self.assertEqual(Field.objects.filter(identifier="212.1_PSCIOS_IOS_0_0_25").count(), 2)
-        self.assertEqual(Field.objects.filter(identifier="212.1_PSCIOS_IOS_0_0_25", present=True,
-                                              updated=True).count(), 1)
+        self.assertEqual(Field.objects.filter(identifier="212.1_PSCIOS_IOS_0_0_25",
+                                              present=True, updated=True).count(), 1)
 
     def test_same_dataset_identifier_only_one_error(self):
         catalog = DataJson(os.path.join(SAMPLES_DIR, 'full_ts_data.json'))


### PR DESCRIPTION
Filtra las distribuciones si tienen o no series de tiempo dependiendo del valor de verdad de `DATAJSON_AR_TIME_SERIES_ONLY`
