### PR TITLE
Metadatos enriquecidos en el admin

### DIFF
--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.contrib import admin, messages
 from django.conf.urls import url
 from django.contrib.contenttypes.admin import GenericTabularInline
-from django.contrib.admin.filters import SimpleListFilter
 
 from .views import config_csv
 from .actions import process_node_register_file_action, confirm_delete
@@ -12,24 +11,6 @@ from .utils import download_config_csv
 from .tasks import bulk_whitelist, read_datajson
 from .models import DatasetIndexingFile, NodeRegisterFile, Node, ReadDataJsonTask, Metadata
 from .models import Catalog, Dataset, Distribution, Field
-
-
-class MetaFilter(SimpleListFilter):
-
-    title = 'entidad'
-
-    parameter_name = 'metadata'
-
-    def lookups(self, request, model_admin):
-        return (
-            ('catalog', 'Catálogo'),
-            ('dataset', 'Dataset'),
-        )
-
-    def queryset(self, request, queryset):
-        if self.value():
-            ids = [x.pk for x in queryset if x.content_type.name == self.value()]
-            return queryset.filter(pk__in=ids)
 
 
 class EnhancedMetaAdmin(GenericTabularInline):

--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -54,6 +54,10 @@ class CatalogAdmin(admin.ModelAdmin):
     readonly_fields = ('identifier',)
     list_filter = ('present', 'updated')
 
+    inlines = (
+        EnhancedMetaAdmin,
+    )
+
     def get_search_results(self, request, queryset, search_term):
         queryset, distinct = \
             super(CatalogAdmin, self).get_search_results(request, queryset, search_term)
@@ -75,6 +79,10 @@ class DatasetAdmin(admin.ModelAdmin):
     actions = ['make_indexable', 'make_unindexable', 'generate_config_file']
 
     list_filter = ('catalog__identifier', 'present', 'indexable')
+
+    inlines = (
+        EnhancedMetaAdmin,
+    )
 
     def make_unindexable(self, _, queryset):
         queryset.update(indexable=False)
@@ -112,6 +120,10 @@ class DistributionAdmin(admin.ModelAdmin):
     list_display = ('identifier', 'title', 'get_dataset_title', 'get_catalog_id', 'last_updated', 'present', 'updated')
     search_fields = ('identifier', 'dataset__identifier', 'dataset__catalog__identifier')
     list_filter = ('dataset__catalog__identifier', )
+
+    inlines = (
+        EnhancedMetaAdmin,
+    )
 
     def get_dataset_title(self, obj):
         return obj.dataset.title

--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -33,6 +33,11 @@ class MetaFilter(SimpleListFilter):
 
 
 class EnhancedMetaAdmin(GenericTabularInline):
+    class Media:
+        css = {
+            'all': ('django_datajsonar/css/hide_title.css', )
+        }
+
     readonly_fields = ('key', 'value')
     model = Metadata
     extra = 0

--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -3,13 +3,44 @@ from __future__ import unicode_literals
 
 from django.contrib import admin, messages
 from django.conf.urls import url
+from django.contrib.contenttypes.admin import GenericTabularInline
+from django.contrib.admin.filters import SimpleListFilter
 
 from .views import config_csv
 from .actions import process_node_register_file_action, confirm_delete
 from .utils import download_config_csv
 from .tasks import bulk_whitelist, read_datajson
-from .models import DatasetIndexingFile, NodeRegisterFile, Node, ReadDataJsonTask
+from .models import DatasetIndexingFile, NodeRegisterFile, Node, ReadDataJsonTask, Metadata
 from .models import Catalog, Dataset, Distribution, Field
+
+
+class MetaFilter(SimpleListFilter):
+
+    title = 'entidad'
+
+    parameter_name = 'metadata'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('catalog', 'Catálogo'),
+            ('dataset', 'Dataset'),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value():
+            ids = [x.pk for x in queryset if x.content_type.name == self.value()]
+            return queryset.filter(pk__in=ids)
+
+
+class EnhancedMetaAdmin(GenericTabularInline):
+    readonly_fields = ('key', 'value')
+    model = Metadata
+    extra = 0
+    can_delete = False
+
+    def has_add_permission(self, request):
+        # Borra el botoncito de add new
+        return False
 
 
 class CatalogAdmin(admin.ModelAdmin):
@@ -110,6 +141,10 @@ class FieldAdmin(admin.ModelAdmin):
     )
     list_filter = (
         'distribution__dataset__catalog__identifier',
+    )
+
+    inlines = (
+        EnhancedMetaAdmin,
     )
 
     def get_catalog_id(self, obj):

--- a/django_datajsonar/models.py
+++ b/django_datajsonar/models.py
@@ -10,6 +10,9 @@ from django.contrib.contenttypes.models import ContentType
 
 
 class Metadata(models.Model):
+    class Meta:
+        verbose_name = verbose_name_plural = "Metadatos enriquecidos"
+
     key = models.CharField(max_length=64)
     value = models.TextField()
 

--- a/django_datajsonar/static/django_datajsonar/css/hide_title.css
+++ b/django_datajsonar/static/django_datajsonar/css/hide_title.css
@@ -1,0 +1,7 @@
+.inline-group .tabular tr.has_original td {
+    padding-top: 8px;
+}
+
+.original {
+    display: none;
+}


### PR DESCRIPTION
Agregar un `TabularInlineModelAdmin` para mostrar los metadatos enriquecidos de cada entidad en el admin.


![screenshot_2018-07-16 change field django site admin](https://user-images.githubusercontent.com/19612265/42766846-d94f57ac-88f1-11e8-9b57-416ef02e55a7.png)
