### PR TITLE
Abstract tasks scheduling

### DIFF
--- a/conf/settings/base.py
+++ b/conf/settings/base.py
@@ -117,7 +117,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/Argentina/Buenos_Aires'
 
 USE_I18N = True
 

--- a/conf/settings/base.py
+++ b/conf/settings/base.py
@@ -183,3 +183,22 @@ FIELD_BLACKLIST = [
     "scrapingIdentifierCell",
     "scrapingDataStartCell",
 ]
+
+DEFAULT_TASKS = [
+    {
+        'name': 'Read Datajson Task',
+        'callable': 'django_datajsonar.tasks.schedule_new_read_datajson_task',
+        'start_hour': 3,
+        'start_minute': 0,
+        'interval': 6,
+        'interval_unit': 'hours'
+    },
+    {
+        'name': 'Close Indexing Task',
+        'callable': 'django_datajsonar.indexing.tasks.close_read_datajson_task',
+        'start_hour': 3,
+        'start_minute': 15,
+        'interval': 30,
+        'interval_unit': 'minutes'
+    }
+]

--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -277,6 +277,9 @@ class AbstractTaskAdmin(admin.ModelAdmin):
     # del AbstractTask asociado a este admin, overridear save_model
     # si se quiere otro comportamiento
     task = None
+
+    # String con el fully qualified name del método a llamar cuando
+    # se programa una tarea periódica.
     callable_str = None
 
     def save_model(self, request, obj, form, change):

--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -273,6 +273,7 @@ class AbstractTaskAdmin(admin.ModelAdmin):
     # del AbstractTask asociado a este admin, overridear save_model
     # si se quiere otro comportamiento
     task = None
+    callable_str = None
 
     def save_model(self, request, obj, form, change):
         super(AbstractTaskAdmin, self).save_model(request, obj, form, change)
@@ -281,7 +282,7 @@ class AbstractTaskAdmin(admin.ModelAdmin):
     def add_view(self, request, form_url='', extra_context=None):
         # Bloqueo la creación de nuevos modelos cuando está corriendo la tarea
         if self.model.objects.filter(status=self.model.RUNNING):
-            messages.error(request, "Ya está corriendo una indexación")
+            messages.error(request, "Ya está corriendo una tarea")
             return super(AbstractTaskAdmin, self).changelist_view(request, None)
 
         return super(AbstractTaskAdmin, self).add_view(request, form_url, extra_context)

--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -298,7 +298,7 @@ class AbstractTaskAdmin(admin.ModelAdmin):
 class DataJsonAdmin(AbstractTaskAdmin):
     model = ReadDataJsonTask
     task = read_datajson
-    callable_str = 'django_datajsonar.tasks.read_datajson'
+    callable_str = 'django_datajsonar.tasks.schedule_new_read_datajson_task'
 
     def get_readonly_fields(self, request, obj=None):
         if obj:

--- a/django_datajsonar/forms.py
+++ b/django_datajsonar/forms.py
@@ -1,0 +1,15 @@
+from django import forms
+
+
+from scheduler.models import RepeatableJob
+
+
+class ScheduleJobForm(forms.ModelForm):
+
+    scheduled_time = forms.DateTimeField(widget=forms.widgets.DateTimeInput(attrs={'type': 'datetime-local'}),
+                                         input_formats=['%Y-%m-%dT%H:%M'])
+
+    class Meta:
+        model = RepeatableJob
+        fields = ['name', 'callable', 'interval',
+                  'interval_unit', 'scheduled_time', 'queue']

--- a/django_datajsonar/forms.py
+++ b/django_datajsonar/forms.py
@@ -7,7 +7,8 @@ from scheduler.models import RepeatableJob
 class ScheduleJobForm(forms.ModelForm):
 
     scheduled_time = forms.DateTimeField(widget=forms.widgets.DateTimeInput(attrs={'type': 'datetime-local'}),
-                                         input_formats=['%Y-%m-%dT%H:%M'])
+                                         input_formats=['%Y-%m-%dT%H:%M'],
+                                         help_text='Formato: yyyy-mm-ddTHH:MM')
 
     class Meta:
         model = RepeatableJob

--- a/django_datajsonar/management/commands/schedule_default_tasks.py
+++ b/django_datajsonar/management/commands/schedule_default_tasks.py
@@ -1,0 +1,30 @@
+#! coding: utf-8
+import datetime
+
+from django.core.management import BaseCommand
+from django.conf import settings
+from django.utils.timezone import now
+
+from scheduler.models import RepeatableJob
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        tasks = getattr(settings, 'DEFAULT_TASKS', [])
+        for task in tasks:
+            start_time = now() + datetime.timedelta(days=1)
+            start_time = start_time.replace(hour=task['start_hour'],
+                                            minute=task['start_minute'],
+                                            second=0,
+                                            microsecond=0)
+            RepeatableJob.objects.update_or_create(
+                name=task['name'],
+                defaults={
+                    'callable': task['callable'],
+                    'queue': 'indexing',
+                    'scheduled_time': start_time,
+                    'interval': task['interval'],
+                    'interval_unit': task['interval_unit'],
+                    'repeat': None
+                })

--- a/django_datajsonar/templates/change_list.html
+++ b/django_datajsonar/templates/change_list.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_static %}
+
+{% block object-tools-items %}
+{{ block.super }}
+<li>
+    <a href="{% url 'admin:schedule_task' %}" class="btn btn-high btn-success">Schedule Task</a>
+</li>
+{% endblock %}

--- a/django_datajsonar/templates/scheduler.html
+++ b/django_datajsonar/templates/scheduler.html
@@ -1,24 +1,32 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static %}
+{% load i18n admin_static admin_urls %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}"/>
+{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ app_label|capfirst|escape }}</a>
+        &rsaquo; {% if has_change_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">
+        {{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
+        &rsaquo; {% trans 'Schedule new task' %}
+    </div>
+{% endblock %}
 
 {% block content %}
-<form action={% url 'admin:schedule_task' %} method="post" novalidate>
-  {% csrf_token %}
-  <table border="1">
-    {% for field in form.visible_fields %}
-      <tr>
-        <th>{{ field.label_tag }}</th>
-        <td>
-          {% if field.errors and display_errors %}
-            {{ field.errors }}
-          {% endif %}
-          {{ field }}
-          {{ field.help_text }}
-        </td>
-      </tr>
-    {% endfor %}
-  </table>
-  <button type="submit">Submit</button>
-</form>
-
+    <form action="{% url 'admin:schedule_task' %}" method="post"
+          {% if form.is_multipart %}enctype="multipart/form-data"{% endif %}>
+        {% csrf_token %}
+        <div>
+            {% for fieldset in adminform %}
+                {% include "admin/includes/fieldset.html" %}
+            {% endfor %}
+        </div>
+        <div class="submit-row">
+            <input type="submit" value="Submit" class="default"/>
+        </div>
+    </form>
 {% endblock %}

--- a/django_datajsonar/templates/scheduler.html
+++ b/django_datajsonar/templates/scheduler.html
@@ -1,0 +1,24 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_static %}
+
+{% block content %}
+<form action={% url 'admin:schedule_task' %} method="post" novalidate>
+  {% csrf_token %}
+  <table border="1">
+    {% for field in form.visible_fields %}
+      <tr>
+        <th>{{ field.label_tag }}</th>
+        <td>
+          {% if field.errors and display_errors %}
+            {{ field.errors }}
+          {% endif %}
+          {{ field }}
+          {{ field.help_text }}
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
+  <button type="submit">Submit</button>
+</form>
+
+{% endblock %}

--- a/django_datajsonar/tests/scheduler_tests.py
+++ b/django_datajsonar/tests/scheduler_tests.py
@@ -2,8 +2,10 @@
 
 import datetime
 from django.test import TestCase
+from django.conf import settings
 from django.core.management import call_command
 from django.utils.timezone import now
+
 from scheduler.models import RepeatableJob
 
 
@@ -100,3 +102,73 @@ class ReadDataJsonTest(TestCase):
             args = [profile['command'] + '_other_name']
             with self.assertRaises(ValueError):
                 call_command(profile['command'], *args, **opts)
+
+
+class DefaultTaskSchedulingTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        defaults = [
+            {
+                'name': 'Read Datajson Task',
+                'callable': 'django_datajsonar.tasks.schedule_new_read_datajson_task',
+                'start_hour': 3,
+                'start_minute': 0,
+                'interval': 6,
+                'interval_unit': 'hours'
+            },
+            {
+                'name': 'Close Indexing Task',
+                'callable': 'django_datajsonar.indexing.tasks.close_read_datajson_task',
+                'start_hour': 4,
+                'start_minute': 15,
+                'interval': 30,
+                'interval_unit': 'minutes'
+            }
+        ]
+        setattr(settings, 'DEFAULT_TASKS', defaults)
+        call_command('schedule_default_tasks')
+
+    def test_schedule_jobs(self):
+        self.assertEqual(2, RepeatableJob.objects.all().count())
+        self.assertEqual(1, RepeatableJob.objects.filter(name='Read Datajson Task').count())
+        self.assertEqual(1, RepeatableJob.objects.filter(name='Close Indexing Task').count())
+
+    def test_scheduled_intervals(self):
+        self.assertEqual(6, RepeatableJob.objects.get(name='Read Datajson Task').interval)
+        self.assertEqual('hours', RepeatableJob.objects.get(name='Read Datajson Task').interval_unit)
+        self.assertEqual(30, RepeatableJob.objects.get(name='Close Indexing Task').interval)
+        self.assertEqual('minutes', RepeatableJob.objects.get(name='Close Indexing Task').interval_unit)
+
+    def test_scheduled_callable(self):
+        self.assertEqual('django_datajsonar.tasks.schedule_new_read_datajson_task',
+                         RepeatableJob.objects.get(name='Read Datajson Task').callable)
+        self.assertEqual('django_datajsonar.indexing.tasks.close_read_datajson_task',
+                         RepeatableJob.objects.get(name='Close Indexing Task').callable)
+
+    def test_start_times(self):
+        start_time = now() + datetime.timedelta(days=1)
+        start_time = start_time.replace(hour=3, minute=0, second=0, microsecond=0)
+        self.assertEqual(start_time,
+                         RepeatableJob.objects.get(name='Read Datajson Task').scheduled_time)
+
+        start_time = start_time.replace(hour=4, minute=15, second=0, microsecond=0)
+        self.assertEqual(start_time,
+                         RepeatableJob.objects.get(name='Close Indexing Task').scheduled_time)
+
+    def test_jobs_get_updated(self):
+        new_defaults = [
+            {
+                'name': 'Read Datajson Task',
+                'callable': 'django_datajsonar.tests.scheduler_tests.callable_method',
+                'start_hour': 5,
+                'start_minute': 30,
+                'interval': 3,
+                'interval_unit': 'days'
+            },
+        ]
+        setattr(settings, 'DEFAULT_TASKS', new_defaults)
+        call_command('schedule_default_tasks')
+        self.assertEqual(2, RepeatableJob.objects.all().count())
+        self.assertEqual('django_datajsonar.tests.scheduler_tests.callable_method',
+                         RepeatableJob.objects.get(name='Read Datajson Task').callable)

--- a/django_datajsonar/views.py
+++ b/django_datajsonar/views.py
@@ -23,6 +23,8 @@ def schedule_task(request, callable_str=None):
             return redirect('admin:scheduler_repeatablejob_changelist')
         else:
             display_errors = True
-    form.fields['callable'].widget.attrs['readonly'] = True
+
+    if callable_str is not None:
+        form.fields['callable'].widget.attrs['readonly'] = True
     form.fields['queue'].widget.attrs['readonly'] = True
     return render(request, 'scheduler.html', {'form': form, 'display_errors': display_errors})

--- a/django_datajsonar/views.py
+++ b/django_datajsonar/views.py
@@ -1,9 +1,28 @@
 #!coding=utf8
 
+from django.shortcuts import render, redirect
+
 from .models import Dataset
 from .utils import download_config_csv
+from .forms import ScheduleJobForm
 
 
 def config_csv(_):
     datasets = Dataset.objects.filter(indexable=True)
     return download_config_csv(datasets)
+
+
+def schedule_task(request, callable_str=None):
+    form = ScheduleJobForm({'callable': callable_str, 'queue': 'indexing'})
+    display_errors = False
+
+    if request.method == 'POST':
+        form = ScheduleJobForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('admin:scheduler_repeatablejob_changelist')
+        else:
+            display_errors = True
+    form.fields['callable'].widget.attrs['readonly'] = True
+    form.fields['queue'].widget.attrs['readonly'] = True
+    return render(request, 'scheduler.html', {'form': form, 'display_errors': display_errors})

--- a/django_datajsonar/views.py
+++ b/django_datajsonar/views.py
@@ -1,30 +1,9 @@
 #!coding=utf8
 
-from django.shortcuts import render, redirect
-
 from .models import Dataset
 from .utils import download_config_csv
-from .forms import ScheduleJobForm
 
 
 def config_csv(_):
     datasets = Dataset.objects.filter(indexable=True)
     return download_config_csv(datasets)
-
-
-def schedule_task(request, callable_str=None):
-    form = ScheduleJobForm({'callable': callable_str, 'queue': 'indexing'})
-    display_errors = False
-
-    if request.method == 'POST':
-        form = ScheduleJobForm(request.POST)
-        if form.is_valid():
-            form.save()
-            return redirect('admin:scheduler_repeatablejob_changelist')
-        else:
-            display_errors = True
-
-    if callable_str is not None:
-        form.fields['callable'].widget.attrs['readonly'] = True
-    form.fields['queue'].widget.attrs['readonly'] = True
-    return render(request, 'scheduler.html', {'form': form, 'display_errors': display_errors})

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -145,3 +145,30 @@ Luego seleccionamos la instancia y usamos la accion "Process node file", como se
 
 Eso procesa el archivo (puede tardar un poco), y al terminar veremos los datasets marcados como indexables en
 `/admin/django_datajsonar/node/`.
+
+### Definición de tareas default
+
+Es posible definir tareas default en los settings de la aplicación. En el archivo de settings definir la lista:
+
+```
+DEFAULT_TASKS = [
+
+    ...
+
+    {
+        'name': <nombre>,
+        'callable': <callable del metodo a ejecutar>,
+        'start_hour': <hora de inicio>,
+        'start_minute': <minuto de inicio>,
+        'interval': <intervalo con el cual se repite el job>,
+        'interval_unit': <minutes|hours|days|weeks>,
+    },
+    
+    ...
+}
+``` 
+
+Cada diccionario define una tarea a ser programada por `django-rq-scheduling`. LlamaR al comando 
+`python manage.py schedule_default_tasks` crea los repeatable jobs ahí definidos. (Nota: en caso de 
+tener una tarea con un nombre ya definido en los defaults, llamar el comando actualizará esta tarea
+con los valores definidos en `DEFAULT_TASKS`)

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -168,7 +168,7 @@ DEFAULT_TASKS = [
 }
 ``` 
 
-Cada diccionario define una tarea a ser programada por `django-rq-scheduling`. LlamaR al comando 
+Cada diccionario define una tarea a ser programada por `django-rq-scheduling`. Llamar al comando 
 `python manage.py schedule_default_tasks` crea los repeatable jobs ahí definidos. (Nota: en caso de 
 tener una tarea con un nombre ya definido en los defaults, llamar el comando actualizará esta tarea
 con los valores definidos en `DEFAULT_TASKS`)


### PR DESCRIPTION
Closes #51 

- Agrega un formulario para programar `RepeatableJobs` más fácilmente. Si el task tiene un atributo `callable_str`, llena el campo automáticamente con este en un readonly field. En otro caso, pide el callable.
- Agrega un management command para programar `RepeatableJobs` definidos en los settings de la aplicación.
- Agrega tests del management command.
- Agrega documentación.