### PR TITLE
Parametrizo el storage de las distribuciones

### DIFF
--- a/django_datajsonar/models.py
+++ b/django_datajsonar/models.py
@@ -91,7 +91,7 @@ class Distribution(models.Model):
     data_hash = models.CharField(max_length=128, default='')
     last_updated = models.DateTimeField(blank=True, null=True)
     data_file = models.FileField(
-        storage=getattr(settings, 'DATAJSONAR_AR_DISTRIBUTION_STORAGE', None),
+        storage=getattr(settings, 'DATAJSON_AR_DISTRIBUTION_STORAGE', None),
         max_length=2000,
         upload_to=filepath,
         blank=True

--- a/django_datajsonar/models.py
+++ b/django_datajsonar/models.py
@@ -91,6 +91,7 @@ class Distribution(models.Model):
     data_hash = models.CharField(max_length=128, default='')
     last_updated = models.DateTimeField(blank=True, null=True)
     data_file = models.FileField(
+        storage=getattr(settings, 'DATAJSONAR_AR_DISTRIBUTION_STORAGE', None),
         max_length=2000,
         upload_to=filepath,
         blank=True

--- a/docs/uso.md
+++ b/docs/uso.md
@@ -172,3 +172,8 @@ Cada diccionario define una tarea a ser programada por `django-rq-scheduling`. L
 `python manage.py schedule_default_tasks` crea los repeatable jobs ahí definidos. (Nota: en caso de 
 tener una tarea con un nombre ya definido en los defaults, llamar el comando actualizará esta tarea
 con los valores definidos en `DEFAULT_TASKS`)
+
+
+### Definir un storage para las distribuciones 
+
+En los settings se puede definir una clase que herede de `Storage` de django para guardar los archivos de distribuciones: `DATAJSON_AR_DISTRIBUTION_STORAGE`


### PR DESCRIPTION
Si `storage` vale `None` django por default agarra el default storage (que estamos usando actualmente)