### PR TITLE
desambiguo la resolucion de urls de schedule_task

### DIFF
--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -296,10 +296,11 @@ class AbstractTaskAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urls = super(AbstractTaskAdmin, self).get_urls()
+        info = self.model._meta.app_label, self.model._meta.model_name
         extra_urls = [url(r'^schedule_task$',
                           self.admin_site.admin_view(self.schedule_task),
                           {'callable_str': self.callable_str},
-                          name='schedule_task'), ]
+                          name='%s_%s_schedule_task' % info), ]
         return extra_urls + urls
 
     def schedule_task(self, request, callable_str):

--- a/django_datajsonar/templates/change_list.html
+++ b/django_datajsonar/templates/change_list.html
@@ -4,6 +4,6 @@
 {% block object-tools-items %}
 {{ block.super }}
 <li>
-    <a href="{% url 'admin:schedule_task' %}" class="btn btn-high btn-success">Schedule Task</a>
+    <a href="{% url 'admin:'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_schedule_task' %}" class="btn btn-high btn-success">Schedule Task</a>
 </li>
 {% endblock %}

--- a/django_datajsonar/templates/scheduler.html
+++ b/django_datajsonar/templates/scheduler.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-    <form action="{% url 'admin:schedule_task' %}" method="post"
+    <form action="{% url 'admin:'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_schedule_task' %}" method="post"
           {% if form.is_multipart %}enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <div>


### PR DESCRIPTION
Agrega la información de la aplicación y el nombre del modelo al nombre de la url con el mismo esquema que usa el admin de django.