### PR TITLE
Fuerzo las tareas de stages a ser async

### DIFF
--- a/django_datajsonar/models.py
+++ b/django_datajsonar/models.py
@@ -373,7 +373,8 @@ class Stage(models.Model):
             return None
 
     def open_stage(self):
-        run_callable(self.callable_str)
+        job = import_string(self.callable_str)
+        job.delay()
         self.status = Stage.ACTIVE
         self.save()
 
@@ -394,23 +395,33 @@ class Stage(models.Model):
         try:
             method = import_string(self.callable_str)
             if not callable(method):
-                errors.update({'callable_str': ValidationError('callable_str must be callable')})
+                msg = 'callable_str must be callable: {}'.format(self.callable_str)
+                errors.update({'callable_str': ValidationError(msg)})
+
+            if not hasattr(method, 'delay'):
+                msg = 'method referenced is not an rq job (has no "delay" attribute: {}'.format(self.callable_str)
+                errors.update({'callable_str': msg})
+
         except (ImportError, ValueError):
-            errors.update({'callable_str': ValidationError('Unable to import callable_str')})
+            msg = 'Unable to import callable_str: {}'.format(self.callable_str)
+            errors.update({'callable_str': ValidationError(msg)})
 
         if self.queue not in settings.RQ_QUEUES:
-            errors.update({'queue': ValidationError('Must be a settings defined queue')})
+            msg = 'Queue is not defined in settings: {}'.format(self.queue)
+            errors.update({'queue': ValidationError(msg)})
 
         if self.task:
             try:
                 task_model = import_string(self.task)
                 if not issubclass(task_model, AbstractTask):
-                    errors.update({'task': ValidationError('task must be an AbstractTask subclass')})
+                    msg = 'task must be an AbstractTask subclass: {}'.format(self.task)
+                    errors.update({'task': ValidationError(msg)})
             except (ImportError, TypeError, ValueError):
                 errors.update({'task': ValidationError('If present, task must be importable')})
 
         if self.next_stage and self.pk and self.next_stage.pk == self.pk:
-            errors.update({'next_stage': ValidationError('next_stage must point to a different_stage')})
+            msg = 'next_stage must point to a different_stage: {}'.format(self)
+            errors.update({'next_stage': ValidationError(msg)})
 
         if errors:
             raise ValidationError(errors)

--- a/django_datajsonar/tasks.py
+++ b/django_datajsonar/tasks.py
@@ -102,9 +102,11 @@ def schedule_new_read_datajson_task(mode=None):
     return new_task
 
 
+@job("indexing")
 def schedule_full_read_task():
     return schedule_new_read_datajson_task(mode=ReadDataJsonTask.COMPLETE_RUN)
 
 
+@job("indexing")
 def schedule_metadata_read_task():
     return schedule_new_read_datajson_task(mode=ReadDataJsonTask.METADATA_ONLY)

--- a/django_datajsonar/tests/synchro_tests.py
+++ b/django_datajsonar/tests/synchro_tests.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+from django_rq import job
 
 try:
-    from mock import patch
+    from mock import patch, MagicMock
 except ImportError:
-    from unittest.mock import patch
+    from unittest.mock import patch, MagicMock
 
 from django.test import TestCase
 from django.core.exceptions import ValidationError
@@ -14,17 +15,18 @@ from django_datajsonar.models import Synchronizer, Stage, ReadDataJsonTask
 from django_datajsonar.synchronizer_tasks import start_synchros, upkeep
 
 
+@job("default")
 def callable_method():
     pass
 
 
 class SynchronizationTests(TestCase):
+
     @classmethod
     def setUpTestData(cls):
-        # Create stages
         previous_stage = None
         for x in range(0, 3):
-            new_stage = Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_new_read_datajson_task',
+            new_stage = Stage.objects.create(callable_str='django_datajsonar.tests.synchro_tests.callable_method',
                                              task='django_datajsonar.models.ReadDataJsonTask',
                                              queue='indexing', next_stage=previous_stage, name='stage ' + str(x))
             previous_stage = new_stage
@@ -32,7 +34,7 @@ class SynchronizationTests(TestCase):
 
     def test_create_stage_with_no_name(self):
         with self.assertRaises(ValidationError):
-            Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_new_read_datajson_task',
+            Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_full_read_task13',
                                  task='django_datajsonar.models.ReadDataJsonTask',
                                  queue='indexing')
 
@@ -47,15 +49,15 @@ class SynchronizationTests(TestCase):
                                  task='django_datajsonar.models.ReadDataJsonTask',
                                  queue='indexing', name='stage fail')
 
-    def test_create_stage_with_uninportable_task(self):
+    def test_create_stage_with_unimportable_task(self):
         with self.assertRaises(ValidationError):
-            Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_new_read_datajson_task',
+            Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_full_read_task',
                                  task='django_datajsonar.models',
                                  queue='indexing', name='stage fail')
 
     def test_save_self_referential_stage(self):
         with self.assertRaises(ValidationError):
-            stage = Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_new_read_datajson_task',
+            stage = Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_full_read_task',
                                          task='django_datajsonar.models.ReadDatajsonTask',
                                          queue='indexing', name='self referential')
             stage.next_stage = stage
@@ -63,7 +65,7 @@ class SynchronizationTests(TestCase):
 
     def test_save_with_bad_queue(self):
         with self.assertRaises(ValidationError):
-            Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_new_read_datajson_task',
+            Stage.objects.create(callable_str='django_datajsonar.tasks.schedule_full_read_task',
                                  task='django_datajsonar.models.ReadDatajsonTask',
                                  queue='bad_queue', name='stage fail')
 
@@ -86,6 +88,16 @@ class SynchronizationTests(TestCase):
         synchro.refresh_from_db()
         self.assertEqual(synchro.actual_stage, synchro.start_stage.next_stage)
 
+    @patch('django_datajsonar.tests.synchro_tests.callable_method')
+    @patch('django_datajsonar.models.pending_or_running_jobs')
+    def test_synchronizator_runs_task(self, mock_queue, mock_method):
+        mock_queue.return_value = False
+        self.assertEqual(0, mock_method.delay.call_count)
+        start_synchros()
+        self.assertEqual(1, mock_method.delay.call_count)
+        upkeep()
+        self.assertEqual(2, mock_method.delay.call_count)
+
     @patch('django_datajsonar.models.pending_or_running_jobs')
     def test_complete_stage_before_advancing(self, mock_queue):
         mock_queue.jobs.return_value = True
@@ -102,15 +114,6 @@ class SynchronizationTests(TestCase):
         self.assertEqual(synchro.actual_stage, synchro.start_stage)
 
     @patch('django_datajsonar.models.pending_or_running_jobs')
-    def test_synchronizator_runs_task(self, mock_queue):
-        mock_queue.return_value = False
-        self.assertEqual(0, ReadDataJsonTask.objects.all().count())
-        start_synchros()
-        self.assertEqual(1, ReadDataJsonTask.objects.all().count())
-        upkeep()
-        self.assertEqual(2, ReadDataJsonTask.objects.all().count())
-
-    @patch('django_datajsonar.models.pending_or_running_jobs')
     def test_synchronizator_finishes_correctly(self, mock_queue):
         mock_queue.return_value = False
         synchro = Synchronizer.objects.get(name='test_synchro')
@@ -120,14 +123,6 @@ class SynchronizationTests(TestCase):
         synchro.refresh_from_db()
         self.assertEqual(Synchronizer.STAND_BY, synchro.status)
         self.assertIsNone(synchro.actual_stage)
-
-    @patch('django_datajsonar.models.pending_or_running_jobs')
-    def test_stage_closes_task_when_finished(self, mock_queue):
-        mock_queue.return_value = False
-        start_synchros()
-        for x in range(0, 3):
-            upkeep()
-        self.assertEqual(3, ReadDataJsonTask.objects.filter(status=ReadDataJsonTask.FINISHED).count())
 
 
 class DefaultTaskSchedulingTest(TestCase):
@@ -146,7 +141,7 @@ class DefaultTaskSchedulingTest(TestCase):
                         },
                         {
                             'name': 'stage_2',
-                            'callable_str': 'django_datajsonar.tasks.schedule_new_read_datajson_task',
+                            'callable_str': 'django_datajsonar.tasks.schedule_full_read_task',
                             'task': 'django_datajsonar.models.ReadDataJsonTask',
                             'queue': 'indexing'
                         },
@@ -158,7 +153,7 @@ class DefaultTaskSchedulingTest(TestCase):
                     [
                         {
                             'name': 'stage_3',
-                            'callable_str': 'django_datajsonar.tasks.schedule_new_read_datajson_task',
+                            'callable_str': 'django_datajsonar.tasks.schedule_full_read_task',
                             'task': 'django_datajsonar.models.ReadDataJsonTask',
                             'queue': 'indexing'
                         },


### PR DESCRIPTION
Se agrega una validación para que el callable_str de los stage
referencien a métodos asincrónicos de rq, chequeando por la existencia
del atributo 'delay', y llamándolo al ejecutarse el stage. Con este
cambio obtenemos una garantía que los stage programados no van a trabar
la acción de upkeep, que debe poder ejecutarse frecuentemente.