### PR TITLE
Unifico views del admin de Synchronizer

### DIFF
--- a/django_datajsonar/admin.py
+++ b/django_datajsonar/admin.py
@@ -367,17 +367,7 @@ class CustomRepeatableJobAdmin(RepeatableJobAdmin):
 
 class SynchronizerAdmin(admin.ModelAdmin):
 
-    change_list_template = 'synchro_change_list.html'
-
-    def get_urls(self):
-        urls = super(SynchronizerAdmin, self).get_urls()
-        info = self.model._meta.app_label, self.model._meta.model_name
-        extra_urls = [url(r'^new_process$',
-                          self.admin_site.admin_view(self.new_process),
-                          name='%s_%s_new_process' % info), ]
-        return extra_urls + urls
-
-    def new_process(self, request):
+    def add_view(self, request, form_url='', extra_context=None):
         synchro_form = SynchroForm()
 
         context = {

--- a/django_datajsonar/templates/synchro_change_list.html
+++ b/django_datajsonar/templates/synchro_change_list.html
@@ -1,9 +1,0 @@
-{% extends "admin/change_list.html" %}
-{% load i18n admin_static %}
-
-{% block object-tools-items %}
-{{ block.super }}
-<li>
-    <a href="{% url 'admin:django_datajsonar_synchronizer_new_process' %}" class="btn btn-high btn-success">Create new process</a>
-</li>
-{% endblock %}

--- a/django_datajsonar/templates/synchronizer.html
+++ b/django_datajsonar/templates/synchronizer.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-    <form action="{% url 'admin:'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_new_process' %}" method="post"
+    <form action="{% url 'admin:'|add:opts.app_label|add:'_'|add:opts.model_name|add:'_add' %}" method="post"
         {% if form.is_multipart %}enctype="multipart/form-data"{% endif %} id="synchroForm">
         {% csrf_token %}
         <div>


### PR DESCRIPTION
La view custom de "create process" pasa a reemplazar la vista default
del admin, add_view. Esto hace que todos los botones del admin de crear
un nuevo modelo pasen a mostrar la vista de nuevo proceso, que también
maneja la creación de los stages.