### PR TITLE
Evito encoding en utf8

### DIFF
--- a/django_datajsonar/indexing/database_loader.py
+++ b/django_datajsonar/indexing/database_loader.py
@@ -179,8 +179,8 @@ class DatabaseLoader(object):
         if not file_url:
             return False
         if self.read_local:  # Usado en debug y testing
-            with open(file_url) as f:
-                data_hash = hashlib.sha512(f.read().encode('utf-8')).hexdigest()
+            with open(file_url, 'rb') as f:
+                data_hash = hashlib.sha512(f.read()).hexdigest()
             distribution_model.data_file = File(open(file_url, 'rb'))
 
         else:


### PR DESCRIPTION
Por alguna razón estabamos leyendo el archivo como UTF-8 y luego pasandolo a bytes, mejor leamos bytes directamente. Evita problemas cuando el archivo está en latin-1