### PR TITLE
178 distribuciones full metadata

### DIFF
--- a/django_datajsonar/tests/distribution_metadata_generator_tests.py
+++ b/django_datajsonar/tests/distribution_metadata_generator_tests.py
@@ -17,7 +17,8 @@ class DistributionMetadataGenerator(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.task = ReadDataJsonTask.objects.create()
+        cls.task = ReadDataJsonTask.objects.create(
+            indexing_mode=ReadDataJsonTask.METADATA_ONLY)
         cls.node = Node(catalog_id=cls.catalog_id, catalog_url=cls.catalog,
                         indexable=True)
         cls.node.save()
@@ -62,3 +63,42 @@ class DistributionMetadataGenerator(TestCase):
         result = get_distributions_metadata()
         distribution = result[0]
         self.assertIsNone(distribution['download_url'])
+
+    def test_distribution_metadata_field_values(self):
+        result = get_distributions_metadata()
+        distribution = result[0]
+        self.assertEqual('https://www.minhacienda.gob.ar/secretarias/'
+                         'politica-economica/programacion-macroeconomica/',
+                         distribution['accessURL'])
+        self.assertEqual('file', distribution['type'])
+        self.assertEqual('CSV', distribution['format'])
+        self.assertNotIn('metadata', distribution)
+
+    def test_dataset_metadata_field_values(self):
+        result = get_distributions_metadata()
+        distribution = result[0]
+        self.assertEqual('Componentes desestacionalizados de la oferta y '
+                         'demanda globales a precios de 1993.',
+                         distribution['dataset_description'])
+        self.assertEqual('Subsecretaría de Programación Macroeconómica.',
+                         distribution['dataset_publisher'])
+        self.assertEqual('datoseconomicos@mecon.gov.ar',
+                         distribution['dataset_publisher_mail'])
+        self.assertEqual('datoseconomicos@mecon.gov.ar',
+                         distribution['dataset_publisher_mail'])
+        self.assertEqual('Instituto Nacional de Estadística y Censos (INDEC)',
+                         distribution['dataset_source'])
+        self.assertEqual('actividad', distribution['dataset_theme'])
+        self.assertEqual('ECON', distribution['dataset_superTheme'])
+
+    def test_catalog_metadata_field_values(self):
+        result = get_distributions_metadata()
+        distribution = result[0]
+        self.assertEqual('Subsecretaría de Programación Macroeconómica.',
+                         distribution['catalog_publisher'])
+
+    def test_missing_metadata_values_passed_as_none(self):
+        result = get_distributions_metadata()
+        distribution = result[1]
+        self.assertIsNone(distribution['type'])
+        self.assertIsNone(distribution['dataset_license'])

--- a/django_datajsonar/tests/samples/sample_data.json
+++ b/django_datajsonar/tests/samples/sample_data.json
@@ -138,6 +138,7 @@
           ],
           "draft": false,
           "identifier": "1.1",
+          "type": "file",
           "scrapingFileURL": "https://www.economia.gob.ar/download/infoeco/actividad_ied.xlsx"
         },
         {

--- a/django_datajsonar/urls.py
+++ b/django_datajsonar/urls.py
@@ -3,13 +3,16 @@ from django.conf.urls import url
 from django_datajsonar.views import nodes_metadata_json, \
     nodes_english_metadata_csv, nodes_spanish_metadata_csv, \
     nodes_english_metadata_xlsx, nodes_spanish_metadata_xlsx, \
-    distributions_spanish_metadata_csv
+    distributions_spanish_metadata_csv, distributions_spanish_metadata_xlsx
 
 urlpatterns = [
-    url(r'^nodes.json/$', nodes_metadata_json),
-    url(r'^nodes.csv/$', nodes_english_metadata_csv),
-    url(r'^nodos.csv/$', nodes_spanish_metadata_csv),
-    url(r'^nodes.xlsx/$', nodes_english_metadata_xlsx),
-    url(r'^nodos.xlsx/$', nodes_spanish_metadata_xlsx),
-    url(r'^distribuciones.csv/$', distributions_spanish_metadata_csv),
+    url(r'^nodes.json/$', nodes_metadata_json, name='nodes_json'),
+    url(r'^nodes.csv/$', nodes_english_metadata_csv, name='nodes_csv'),
+    url(r'^nodos.csv/$', nodes_spanish_metadata_csv, name='nodos_csv'),
+    url(r'^nodes.xlsx/$', nodes_english_metadata_xlsx, name='nodes_xlsx'),
+    url(r'^nodos.xlsx/$', nodes_spanish_metadata_xlsx, name='nodos_json'),
+    url(r'^distribuciones.csv/$', distributions_spanish_metadata_csv,
+        name='distribuciones_csv'),
+    url(r'^distribuciones.xlsx/$', distributions_spanish_metadata_xlsx,
+        name='distribuciones_xlsx'),
 ]

--- a/django_datajsonar/utils/download_response_writer.py
+++ b/django_datajsonar/utils/download_response_writer.py
@@ -1,4 +1,6 @@
 #!coding=utf8
+from collections import OrderedDict
+
 from django_datajsonar.utils.metadata_generator import \
     get_jurisdiction_list_metadata, get_distributions_metadata
 
@@ -33,5 +35,6 @@ def flatten_jurisdiction_list_metadata(jurisdictions):
 
 
 def translate_fields(metadata_list, fields_translation):
-    return [{fields_translation[key]: catalog[key]for key in fields_translation}
-            for catalog in metadata_list]
+    return [OrderedDict(
+        {fields_translation[key]: catalog[key]for key in fields_translation})
+        for catalog in metadata_list]

--- a/django_datajsonar/utils/translations.py
+++ b/django_datajsonar/utils/translations.py
@@ -24,11 +24,26 @@ NODES_SPANISH_FIELDS = OrderedDict({
 })
 
 DISTRIBUTIONS_SPANISH_FIELDS = OrderedDict({
+    'dataset__catalog__identifier': 'catalogo_id',
+    'dataset__catalog__title': 'catalogo_titulo',
+    'catalog_publisher': 'catalogo_responsable',
+
+    'dataset__identifier': 'dataset_id',
+    'dataset__title': 'dataset_titulo',
+    'dataset_description': 'dataset_descripcion',
+    'dataset_publisher': 'dataset_responsable',
+    'dataset_publisher_mail': 'dataset_responsable_correo',
+    'dataset_source': 'dataset_fuente',
+    'dataset_theme': 'dataset_tema_especifico',
+    'dataset_superTheme': 'dataset_tema_global',
+    'dataset_license': 'dataset_licencia',
+
     'identifier': 'distribucion_id',
     'title': 'distribucion_titulo',
     'download_url': 'distribucion_url_descarga',
-    'dataset__identifier': 'dataset_id',
-    'dataset__title': 'dataset_titulo',
-    'dataset__catalog__title': 'catalogo_titulo',
-    'dataset__catalog__identifier': 'catalogo_id',
+    'accessURL': 'distribucion_url_acceseo',
+    'type': 'distribucion_tipo',
+    'format': 'distribucion_formato',
+
+
 })

--- a/django_datajsonar/utils/translations.py
+++ b/django_datajsonar/utils/translations.py
@@ -41,7 +41,7 @@ DISTRIBUTIONS_SPANISH_FIELDS = OrderedDict({
     'identifier': 'distribucion_id',
     'title': 'distribucion_titulo',
     'download_url': 'distribucion_url_descarga',
-    'accessURL': 'distribucion_url_acceseo',
+    'accessURL': 'distribucion_url_acceso',
     'type': 'distribucion_tipo',
     'format': 'distribucion_formato',
 

--- a/django_datajsonar/views.py
+++ b/django_datajsonar/views.py
@@ -27,25 +27,35 @@ def nodes_metadata_json(_):
 
 def nodes_english_metadata_csv(_):
     response = generate_csv_download_response('nodes.csv')
-    return write_node_metadata(response, NODES_ENGLISH_FIELDS, CSVMetadataWriter)
+    return write_node_metadata(response, NODES_ENGLISH_FIELDS,
+                               CSVMetadataWriter)
 
 
 def nodes_spanish_metadata_csv(_):
     response = generate_csv_download_response('nodos.csv')
-    return write_node_metadata(response, NODES_SPANISH_FIELDS, CSVMetadataWriter)
+    return write_node_metadata(response, NODES_SPANISH_FIELDS,
+                               CSVMetadataWriter)
 
 
 def nodes_english_metadata_xlsx(_):
     response = generate_xlsx_download_response('nodes.xlsx')
-    return write_node_metadata(response, NODES_ENGLISH_FIELDS, XLSXMetadataWriter)
+    return write_node_metadata(response, NODES_ENGLISH_FIELDS,
+                               XLSXMetadataWriter)
 
 
 def nodes_spanish_metadata_xlsx(_):
     response = generate_xlsx_download_response('nodos.xlsx')
-    return write_node_metadata(response, NODES_SPANISH_FIELDS, XLSXMetadataWriter)
+    return write_node_metadata(response, NODES_SPANISH_FIELDS,
+                               XLSXMetadataWriter)
 
 
 def distributions_spanish_metadata_csv(_):
     response = generate_csv_download_response('distribuciones.csv')
     return write_distributions_metadata(response, DISTRIBUTIONS_SPANISH_FIELDS,
                                         CSVMetadataWriter)
+
+
+def distributions_spanish_metadata_xlsx(_):
+    response = generate_xlsx_download_response('distribuciones.xlsx')
+    return write_distributions_metadata(response, DISTRIBUTIONS_SPANISH_FIELDS,
+                                        XLSXMetadataWriter)


### PR DESCRIPTION
Closes datosgobar/monitoreo-apertura#178

- Agrega al csv los campos que se leen de la metadata de cada modelo
- Agrega tests del comportamiento

(Además, le pone name a las urls de descarga de archivos. Por un tema de buenas prácticas para poder hacer `reverse()` cuando haga falta)