### PR TITLE
Agrego campo de distribucion_descripcion a los CSV, en el orden correspondiente

### DIFF
--- a/django_datajsonar/tests/distribution_metadata_generator_tests.py
+++ b/django_datajsonar/tests/distribution_metadata_generator_tests.py
@@ -72,6 +72,9 @@ class DistributionMetadataGenerator(TestCase):
                          distribution['accessURL'])
         self.assertEqual('file', distribution['type'])
         self.assertEqual('CSV', distribution['format'])
+        self.assertEqual('Oferta y Demanda Globales por componente, a precios de '
+                         'comprador, en millones de pesos de 1993 y valores anuales'
+                         ' desestacionalizados.', distribution['description'])
         self.assertNotIn('metadata', distribution)
 
     def test_dataset_metadata_field_values(self):
@@ -82,8 +85,6 @@ class DistributionMetadataGenerator(TestCase):
                          distribution['dataset_description'])
         self.assertEqual('Subsecretaría de Programación Macroeconómica.',
                          distribution['dataset_publisher'])
-        self.assertEqual('datoseconomicos@mecon.gov.ar',
-                         distribution['dataset_publisher_mail'])
         self.assertEqual('datoseconomicos@mecon.gov.ar',
                          distribution['dataset_publisher_mail'])
         self.assertEqual('Instituto Nacional de Estadística y Censos (INDEC)',

--- a/django_datajsonar/utils/metadata_generator.py
+++ b/django_datajsonar/utils/metadata_generator.py
@@ -80,7 +80,8 @@ def jurisdiction_metadata(jurisdiction):
 
 
 def get_distributions_metadata():
-    metadata_list = list(Distribution.objects.all().select_related('dataset__catalog').values(
+    metadata_list = list(Distribution.objects.all().select_related(
+        'dataset__catalog').order_by('dataset__catalog__title', 'dataset__title', 'title').values(
         'identifier',
         'title',
         'download_url',
@@ -96,6 +97,7 @@ def get_distributions_metadata():
     for distribution in metadata_list:
         distribution_metadata = json.loads(distribution.pop('metadata')) \
             if distribution.get('metadata') else {}
+        distribution['description'] = distribution_metadata.get('description')
         distribution['accessURL'] = distribution_metadata.get('accessURL')
         distribution['type'] = distribution_metadata.get('type')
         distribution['format'] = distribution_metadata.get('format')

--- a/django_datajsonar/utils/metadata_generator.py
+++ b/django_datajsonar/utils/metadata_generator.py
@@ -80,8 +80,7 @@ def jurisdiction_metadata(jurisdiction):
 
 
 def get_distributions_metadata():
-    metadata_list = list(Distribution.objects.all().select_related(
-        'dataset__catalog').order_by('dataset__catalog__title', 'dataset__title', 'title').values(
+    metadata_list = list(Distribution.objects.all().select_related('dataset__catalog').values(
         'identifier',
         'title',
         'download_url',

--- a/django_datajsonar/utils/translations.py
+++ b/django_datajsonar/utils/translations.py
@@ -40,6 +40,7 @@ DISTRIBUTIONS_SPANISH_FIELDS = OrderedDict({
 
     'identifier': 'distribucion_id',
     'title': 'distribucion_titulo',
+    'description': 'distribucion_descripcion',
     'download_url': 'distribucion_url_descarga',
     'accessURL': 'distribucion_url_acceso',
     'type': 'distribucion_tipo',


### PR DESCRIPTION
- Agrego campo `distribucion_descripcion` a los archivos distribuciones.csv, ya que este no existía. Lo ubiqué en donde la descripción del issue especificaba
- Elimino una aserción duplicada de un test
- Agrego aserción para verificar que se esté guardando bien la descripción en el .csv

Closes #149 