### PR TITLE
Fuerzo formato en la creación del Datajson para la creación de archivos

### DIFF
--- a/django_datajsonar/tests/utils_tests/catalog_file_generator_tests.py
+++ b/django_datajsonar/tests/utils_tests/catalog_file_generator_tests.py
@@ -62,3 +62,18 @@ class CatalogFileGeneratorTests(TestCase):
             CatalogFileGenerator(node).generate_files()
         json_gen_mock.assert_called_once()
         xlsx_gen_mock.assert_called_once()
+
+    @patch('django_datajsonar.utils.catalog_file_generator.DataJson')
+    def test_creates_datajson_with_arguments_specified_in_node(self, datajson_mock):
+        node = Node.objects.create(catalog_id='test_catalog',
+                                   catalog_format='json',
+                                   catalog_url='https://fakeurl.com/without_format',
+                                   indexable=True,
+                                   verify_ssl=True)
+        with open_catalog('sample_data.json') as sample:
+            text = sample.read()
+        with requests_mock.Mocker() as m:
+            m.get('https://fakeurl.com/without_format', status_code=200, content=text)
+            CatalogFileGenerator(node).generate_files()
+        datajson_mock.assert_called_once_with(node.catalog_url, catalog_format='json',
+                                              verify_ssl=True)

--- a/django_datajsonar/utils/catalog_file_generator.py
+++ b/django_datajsonar/utils/catalog_file_generator.py
@@ -19,9 +19,10 @@ class CatalogFileGenerator:
 
     def generate_files(self):
         catalog_format = self.node.catalog_format
-
-        catalog = DataJson(self.node.catalog_url)
         catalog_url = self.node.catalog_url
+
+        catalog = DataJson(catalog_url, catalog_format=catalog_format,
+                           verify_ssl=self.node.verify_ssl)
 
         if catalog_format == Node.JSON:
             self._save_json_file_from_url(catalog_url)


### PR DESCRIPTION
No especificar el formato del catalogo a DataJson causaba que pueda tirar una excepcion si el url no tenia un formato especifico.