### PR TITLE
Catálogos en JSON se muestran en browser

### DIFF
--- a/django_datajsonar/tests/view_tests.py
+++ b/django_datajsonar/tests/view_tests.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django_datajsonar.utils.catalog_file_generator import CatalogFileGenerator
 from .helpers import create_node, open_catalog
 
+
 class ViewTests(TestCase):
     def setUp(self):
         self.client = Client()

--- a/django_datajsonar/tests/view_tests.py
+++ b/django_datajsonar/tests/view_tests.py
@@ -1,0 +1,37 @@
+import json
+
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from django_datajsonar.utils.catalog_file_generator import CatalogFileGenerator
+from .helpers import create_node, open_catalog
+
+class ViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_xlsx_file_is_served_as_attachment(self):
+        node = create_node('catalog.xlsx')
+        CatalogFileGenerator(node).generate_files()
+        response = self.client.get(reverse("django_datajsonar:xlsx_catalog",
+                                           args=['test_catalog']))
+        content_disposition = response["Content-Disposition"]
+        self.assertIn("attachment;", content_disposition)
+
+    def test_json_file_is_not_served_as_attachment(self):
+        node = create_node('another_catalog.json')
+        CatalogFileGenerator(node).generate_files()
+        response = self.client.get(reverse("django_datajsonar:json_catalog",
+                                           args=['test_catalog']))
+        content_disposition = response["Content-Disposition"]
+        self.assertNotIn("attachment;", content_disposition)
+
+    def test_json_file_content_in_response_content(self):
+        node = create_node('another_catalog.json')
+        CatalogFileGenerator(node).generate_files()
+        response = self.client.get(reverse("django_datajsonar:json_catalog",
+                                           args=['test_catalog']))
+        response_json = json.loads(response.getvalue().decode('utf-8'))
+        with open_catalog('another_catalog.json') as file:
+            file_json = json.loads(file.read().decode('utf-8'))
+            self.assertEquals(response_json, file_json)

--- a/django_datajsonar/views.py
+++ b/django_datajsonar/views.py
@@ -70,7 +70,7 @@ def json_catalog(_request, catalog_id):
     filename = 'data.json'
     node = Node.objects.get(catalog_id=catalog_id)
     path = node.json_catalog_file.path
-    return catalog_file_response(filename, path, "application/json")
+    return catalog_file_response(filename, path, "application/json", with_attachment=False)
 
 
 def xlsx_catalog(_request, catalog_id):
@@ -82,10 +82,11 @@ def xlsx_catalog(_request, catalog_id):
                                  "spreadsheetml.sheet")
 
 
-def catalog_file_response(filename, path, content_type):
+def catalog_file_response(filename, path, content_type, with_attachment=True):
     if not os.path.exists(path):
         return HttpResponseBadRequest("No hay un archivo generado con ese nombre.")
     response = FileResponse(open(path, 'rb'), content_type=content_type)
-    response["Content-Disposition"] = 'attachment; filename={}'.format(
-        filename)
+    response["Content-Disposition"] = 'filename={}'.format(filename)
+    if with_attachment:
+        response["Content-Disposition"] = "attachment; " + response["Content-Disposition"]
     return response


### PR DESCRIPTION
- Los archivos de catálogos para los nodos en formato JSON ahora se muestran en el browser y no como attachment

Closes #178 