### PR TITLE
Verificacion ssl en creacion de archivos

### DIFF
--- a/django_datajsonar/tests/catalog_reader_tests.py
+++ b/django_datajsonar/tests/catalog_reader_tests.py
@@ -1,14 +1,16 @@
 import os
 from unittest import mock
 
+import requests_mock
 from django.conf import settings
 from django.test import TestCase
 
 from django_datajsonar.indexing.catalog_reader import CatalogReader
 from django_datajsonar.indexing.constants import CATALOG_ROOT
-from django_datajsonar.models import ReadDataJsonTask
+from django_datajsonar.models import ReadDataJsonTask, Node
 from django_datajsonar.models.config import IndexingConfig
-from django_datajsonar.tests.helpers import create_node
+from django_datajsonar.tests.helpers import create_node, open_catalog
+from django_datajsonar.utils.catalog_file_generator import CatalogFileGenerator
 
 
 @mock.patch('django_datajsonar.indexing.catalog_reader.DatabaseLoader')
@@ -45,3 +47,47 @@ class CatalogReaderTests(TestCase):
         CatalogReader().index(node, task)
         self.assertTrue(os.path.exists(json_file_path))
         self.assertTrue(os.path.exists(xlsx_file_path))
+
+    def test_catalog_url_request_does_not_verify_ssl_by_default(self, _database_loader):
+        node = Node.objects.create(catalog_id='test_catalog',
+                                   catalog_format='json',
+                                   catalog_url='https://fakeurl.com/data.json',
+                                   indexable=True)
+        with open_catalog('sample_data.json') as sample:
+            text = sample.read()
+        with requests_mock.Mocker() as m:
+            m.get('https://fakeurl.com/data.json', status_code=200, content=text)
+            CatalogFileGenerator(node).generate_files()
+            self.assertEqual(2, len(m.request_history))
+            for request in m.request_history:
+                self.assertTrue(request.verify)
+
+    def test_catalog_url_request_verifies_ssl_according_to_node(self, _database_loader):
+        node = Node.objects.create(catalog_id='test_catalog',
+                                   catalog_format='json',
+                                   catalog_url='https://fakeurl.com/data.json',
+                                   indexable=True,
+                                   verify_ssl=False)
+        with open_catalog('sample_data.json') as sample:
+            text = sample.read()
+        with requests_mock.Mocker() as m:
+            m.get('https://fakeurl.com/data.json', status_code=200, content=text)
+            CatalogFileGenerator(node).generate_files()
+            self.assertEqual(2, len(m.request_history))
+            for request in m.request_history:
+                self.assertFalse(request.verify)
+
+    def test_catalog_url_request_verifies_ssl_on_enabled_node(self, _database_loader):
+        node = Node.objects.create(catalog_id='test_catalog',
+                                   catalog_format='json',
+                                   catalog_url='https://fakeurl.com/data.json',
+                                   indexable=True,
+                                   verify_ssl=True)
+        with open_catalog('sample_data.json') as sample:
+            text = sample.read()
+        with requests_mock.Mocker() as m:
+            m.get('https://fakeurl.com/data.json', status_code=200, content=text)
+            CatalogFileGenerator(node).generate_files()
+            self.assertEqual(2, len(m.request_history))
+            for request in m.request_history:
+                self.assertTrue(request.verify)

--- a/django_datajsonar/tests/catalog_reader_tests.py
+++ b/django_datajsonar/tests/catalog_reader_tests.py
@@ -60,7 +60,7 @@ class CatalogReaderTests(TestCase):
             CatalogFileGenerator(node).generate_files()
             self.assertEqual(2, len(m.request_history))
             for request in m.request_history:
-                self.assertTrue(request.verify)
+                self.assertFalse(request.verify)
 
     def test_catalog_url_request_verifies_ssl_according_to_node(self, _database_loader):
         node = Node.objects.create(catalog_id='test_catalog',

--- a/django_datajsonar/utils/catalog_file_generator.py
+++ b/django_datajsonar/utils/catalog_file_generator.py
@@ -14,6 +14,7 @@ from django_datajsonar.models import Node
 class CatalogFileGenerator:
     def __init__(self, node):
         self.node = node
+        self.verify_ssl = node.verify_ssl
         self.xlsx_catalog_dir = os.path.join(settings.MEDIA_ROOT, 'catalog', self.node.catalog_id, 'catalog.xlsx')
         self.json_catalog_dir = os.path.join(settings.MEDIA_ROOT, 'catalog', self.node.catalog_id, 'data.json')
 
@@ -22,7 +23,7 @@ class CatalogFileGenerator:
         catalog_url = self.node.catalog_url
 
         catalog = DataJson(catalog_url, catalog_format=catalog_format,
-                           verify_ssl=self.node.verify_ssl)
+                           verify_ssl=self.verify_ssl)
 
         if catalog_format == Node.JSON:
             self._save_json_file_from_url(catalog_url)
@@ -43,7 +44,7 @@ class CatalogFileGenerator:
         self.node.xlsx_catalog_file.save('catalog.xlsx', ContentFile(file_content))
 
     def _get_catalog_content_from_url(self, url):
-        response = requests.get(url)
+        response = requests.get(url, verify=self.verify_ssl)
         response.raise_for_status()
         return response.content
 


### PR DESCRIPTION
Closes #186 

En una lectura de catalogos, cuando se descargan catalogos por url en la creacion de archivos de un nodo, ahora se verifica o no el certificado ssl segun el campo del nodo